### PR TITLE
createIfNotExists usage

### DIFF
--- a/AsyncMSMQ/MSMQService.cs
+++ b/AsyncMSMQ/MSMQService.cs
@@ -14,19 +14,19 @@ namespace AsyncMSMQ
     {
         private ILogListener _log;
         public string MessageQueuePath { get; private set; }
-        
+
         public MSMQService(string queuePath, bool createIfNotExists, ILogListener logListener)
         {
             if (logListener == null) throw new ArgumentNullException("LogListener cannot be null");
 
             _log = logListener;
             MessageQueuePath = queuePath;
-            CreateQueue(createIfNotExists);
+            if (createIfNotExists) CreateQueueIfNotExists();
         }
 
 
         /// <summary>
-        /// Asynchronous receive messages from specified MessageQueue 
+        /// Asynchronous receive messages from specified MessageQueue
         /// </summary>
         /// <typeparam name="T">Body stream is of type T</typeparam>
         /// <returns>Object of type T</returns>
@@ -47,7 +47,7 @@ namespace AsyncMSMQ
 
 
         /// <summary>
-        /// Asynchronous receive messages from specified MessageQueue 
+        /// Asynchronous receive messages from specified MessageQueue
         /// </summary>
         /// <typeparam name="T">Body stream is of type T</typeparam>
         /// <returns>Object of type T</returns>
@@ -222,7 +222,7 @@ namespace AsyncMSMQ
             });
         }
 
-        private void CreateQueue(bool createIfNotExists)
+        private void CreateQueueIfNotExists()
         {
             try
             {

--- a/AsyncMSMQ/MSMQService.cs
+++ b/AsyncMSMQ/MSMQService.cs
@@ -233,7 +233,7 @@ namespace AsyncMSMQ
             }
             catch (InvalidOperationException e)
             {
-                throw new InvalidOperationException("createIfNotExists cannot be used on private queues or multicast addresses.")
+                throw new InvalidOperationException("createIfNotExists cannot be used on private queues or multicast addresses.");
             }
             catch (Exception ex)
             {

--- a/AsyncMSMQ/MSMQService.cs
+++ b/AsyncMSMQ/MSMQService.cs
@@ -231,6 +231,10 @@ namespace AsyncMSMQ
                     MessageQueue.Create(MessageQueuePath);
                 }
             }
+            catch (InvalidOperationException e)
+            {
+                throw new InvalidOperationException("createIfNotExists cannot be used on private queues or multicast addresses.")
+            }
             catch (Exception ex)
             {
                 _log.Error(ex.Message);


### PR DESCRIPTION
Fixes issue #2 (Queue is created even if instantiated with createIfNotExists false)
Addresses issue #1 by throwing an exception when the createIfNotExists parameter is true, while trying to use a private or multicast address.